### PR TITLE
Set PYENV_HOME (in addition to PYENV)

### DIFF
--- a/pyenv-win/chocolateyInstall.ps1.template
+++ b/pyenv-win/chocolateyInstall.ps1.template
@@ -10,6 +10,11 @@ Install-ChocolateyEnvironmentVariable `
     -VariableValue '%USERPROFILE%\.pyenv\pyenv-win\' `
     -VariableType 'User'
 
+Install-ChocolateyEnvironmentVariable `
+    -VariableName 'PYENV_HOME' `
+    -VariableValue '%USERPROFILE%\.pyenv\pyenv-win\' `
+    -VariableType 'User'
+
 Install-ChocolateyPath `
     -PathToInstall '%USERPROFILE%\.pyenv\pyenv-win\bin'
 


### PR DESCRIPTION
[The docs ](https://github.com/pyenv-win/pyenv-win#finish-the-installation) say:

> If you installed using Chocolatey, you can skip to step 3.
> 1. Add PYENV and PYENV_HOME to your Environment Variables

And on https://github.com/pyenv-win/pyenv-win/issues/174#issuecomment-723554741 it's implied that PYENV_HOME is set by Chocolatey.